### PR TITLE
Removed the light class which isn't implemented

### DIFF
--- a/lifx/lifx.py
+++ b/lifx/lifx.py
@@ -1,7 +1,6 @@
 from .enums import *
 from .packet import *
 from .network import Network
-from .light import Light
 
 # Wraps network providing a simpler API.
 class Lifx:


### PR DESCRIPTION
Hey @arrian,

just noticed that the `Light` class isn't implemented and not used in the `Lifx` class, so I removed it.

Best regards,
klarstil
